### PR TITLE
misnamed variable

### DIFF
--- a/libpkpass/commands/command.py
+++ b/libpkpass/commands/command.py
@@ -26,7 +26,7 @@ class Command(object):
                      'pwstore': './passwords',
                      'certpath': './certs',
                      'keypath': './private',
-                     'ca_bundle_path': './certs/ca-bundle',
+                     'cabundle': './certs/ca-bundle',
                      'time': 10,
                      'card_slot': None}
         self.recipient_list = []


### PR DESCRIPTION
There was no reference to ca_bundle_path in the rest of the code, I a…ssumed this variable was intended to be cabundle, and made this change; there was a traceback that was occuring with cabundle did not exist, and it is remediated when cabundle has a default value as defined in the code