### PR TITLE
Adding username to setup script and bundling explanation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ You will want to create a .pkpassrc file in the pkpass repository that you have 
 
 In this case, 'passdb' is the name of the directory in the user's home area that contains x509 certificates, keys (if necessary) and the ca bundle.
 
-You can create a ca bundle by combining all CA Certificates that you trust into one file and moving the file to the cabundle path.  Usually the site admins create this CA Bundle for users as part of their certificate management practices.
+You can create a ca bundle by combining all CA Certificates that you trust into one file and moving the file to the cabundle path.  Usually the site admins create this CA Bundle for users as part of their certificate management practices.  
+Example:  
+```
+cd "${directory_with_ca_certs}"
+cat * > ca.bundle
+cp ca.bundle "${cabundle_path_in_rc_file}"
+```
 
 Additionally, note that arguments you can pass on the command line may be passed in through the .pkpassrc file as well.
 
@@ -150,7 +156,7 @@ keys still need to be signed by a CA in the CA bundle.  Basic usage:
 Create a keypair
 ----------------
 This will create an unsigned keypair.  We really want it to create a certificate request in the future
-`openssl req -newkey rsa:4096 -keyout local.key -x509 -out local.crt`
+`openssl req -newkey rsa:4096 -keyout local.key -x509 -out local.cert`
 
 As long as the private and public keys are in directories that pkpass can find, distribution to those identities works exactly the same.  Keys must be named 'username.key'.  For user foo, the private key must be named 'foo.key' and reside in the keypath directory.
 

--- a/setup.sh
+++ b/setup.sh
@@ -88,14 +88,17 @@ mkdir -p "${pwstore}"
 pkcs11-tool -L
 
 read -rp "Available slots listed above, which would you like to use? (defaults to 0): " cardslot
-
 cardslot="${cardslot:-0}"
+
+read -rp "What user name would you like to use? (defaults to system user): " identity
+identity="${identity:-$(whoami)}"
 
 echo -e "certpath: $certpath 
 keypath: $keypath
 cabundle: $cabundle
 pwstore: $pwstore
-card_slot: $cardslot" > .pkpassrc
+card_slot: $cardslot
+identity: $identity" > .pkpassrc
  
 read -rp "Would you like to install the python requirements as root(0),user(1),or venv(2)?" pinstall
 


### PR DESCRIPTION
Completing basic functionality of setup script to allow for easier command line usage.
Adding explanation of how to bundle ca certs into a ca bundle in the readme by the section that was already speaking about bundling
closes #5