### PR TITLE
Ngin add group functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,17 @@ Configuring the Tool
 Password Repository
 -------------------
 
-Passwords are created on the file system, so any destination may be specified.  For passwords that need to be distributed to other users, convention suggests putting these into a hierarchy with the root in 'passwords'.  To make the repository as flat as possible, the top level will contain mostly groupings of passwords, with the next level containing the passwords themselves.  Examples of groups may include "security-team", "database-users", "passwords/general", etc.  It is up to each organization to determine the best hierarchy for storing passwords.  The 'list' command and 'showall' commands will crawl the hierarchy starting at the root regardless of structure.
+Passwords are created on the file system, so any destination may be specified.  For passwords that need to be distributed to other users, convention suggests putting these into a hierarchy with the root in 'passwords'.  To make the repository as flat as possible, the top level will contain mostly groupings of passwords, with the next level containing the passwords themselves.  
+Examples of groups may include "security-team", "database-users", "passwords/general", etc.  It is up to each organization to determine the best hierarchy for storing passwords.  The 'list' command and 'showall' commands will crawl the hierarchy starting at the root regardless of structure.
+
+You may distribute passwords to a specified group defined in your pkpassrc file. These groups may be arbitrary
+```
+databaseadmins: db1, db2,db3
+secadmins: admin1,  admin2 ,  admin3
+groups: secadmins, databaseadmins
+```
+
+you may also specify on the command line which groups to use: ` pkpass.py distribute password -g secadmins`
 
 Special Treatment for Non-piv accounts/credentials
 ====================

--- a/libpkpass/commands/command.py
+++ b/libpkpass/commands/command.py
@@ -143,8 +143,9 @@ class Command(object):
     def _build_recipient_list(self):
         try:
             if 'groups' in self.args and self.args['groups'] is not None:
-                self._parse_group_membership()
-            self.recipient_list += self.args['users'].split(',')
+                self.recipient_list += self._parse_group_membership()
+            if 'users' in self.args and self.args['users'] is not None:
+                self.recipient_list += self.args['users'].split(',')
             self.recipient_list = [x.strip() for x in self.recipient_list]
             for user in self.recipient_list:
                 if str(user) == '':
@@ -153,11 +154,11 @@ class Command(object):
             pass
 
     def _parse_group_membership(self):
+        member_list = []
         try:
-            if 'users' not in self.args or self.args['users'] is None:
-                self.args['users'] = ""
             for group in self.args['groups'].split(','):
-                self.recipient_list += self.args[group.strip()].split(',')
+                member_list += self.args[group.strip()].split(',')
+            return member_list
         except KeyError as err:
             raise GroupDefinitionError(str(err))
 

--- a/libpkpass/commands/command.py
+++ b/libpkpass/commands/command.py
@@ -10,7 +10,7 @@ from six import iteritems as iteritems
 from libpkpass.commands.arguments import ARGUMENTS as arguments
 from libpkpass.password import PasswordEntry
 from libpkpass.identities import IdentityDB
-from libpkpass.errors import NullRecipientError, CliArgumentError, FileOpenError
+from libpkpass.errors import NullRecipientError, CliArgumentError, FileOpenError, GroupDefinitionError
 
 
 class Command(object):
@@ -142,12 +142,24 @@ class Command(object):
 
     def _build_recipient_list(self):
         try:
-            self.recipient_list = self.args['users'].split(',')
+            if 'groups' in self.args and self.args['groups'] is not None:
+                self._parse_group_membership()
+            self.recipient_list += self.args['users'].split(',')
+            self.recipient_list = [x.strip() for x in self.recipient_list]
             for user in self.recipient_list:
                 if str(user) == '':
                     raise NullRecipientError
         except KeyError:  # If this is a command with no users, don't worry about it
             pass
+
+    def _parse_group_membership(self):
+        try:
+            if 'users' not in self.args or self.args['users'] is None:
+                self.args['users'] = ""
+            for group in self.args['groups'].split(','):
+                self.recipient_list += self.args[group.strip()].split(',')
+        except KeyError as err:
+            raise GroupDefinitionError(str(err))
 
     def _get_config_args(self, config):
         try:

--- a/libpkpass/errors.py
+++ b/libpkpass/errors.py
@@ -27,6 +27,10 @@ class FileOpenError(PKPassError):
         self.msg = "File %s found in config, could not be opened due to %s" % (
             value, reason)
 
+class GroupDefinitionError(PKPassError):
+    def __init__(self, value):
+        self.msg = "Group %s is not defined in the config" % (value)
+
 class LegacyImportFormatError(PKPassError):
     def __init__(self):
         self.msg = "Passwords in import file not in key:value notation"


### PR DESCRIPTION
This allows users to custom define user groups in their rc file. They can then reference these groups on distribution of passwords; helping alleviate the possibility of forgetting a user on distribution.