### PR TITLE
wanted to rebrand nginsecretsharing

### DIFF
--- a/libpkpass/escrow.py
+++ b/libpkpass/escrow.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """This Module handles the escrow functions i.e. creating shares and recovery"""
 
-from nginsecretsharing import PlaintextToHexSecretSharer as ptohss
+from pyseltongue import PlaintextToHexSecretSharer as ptohss
 from .errors import EscrowError
 
 ##############################################################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 cryptography>=2.3
 exrex>=0.10.5
 future>=0.17.1
-nginsecretsharing>=0.3.0
+mock>=3.0.5
+pyseltongue>=0.3.1
 pyperclip>=1.6.0
 PyYAML>=4.2b1
 setuptools>=41.2.0


### PR DESCRIPTION
original writers are not maintaining secretsharing, pyseltongue is more community appropriate as it is not based on my name, but the name of the implementation language