### PR TITLE
Add a missing space to the introduction string

### DIFF
--- a/libpkpass/commands/interpreter.py
+++ b/libpkpass/commands/interpreter.py
@@ -60,7 +60,7 @@ def pkparse_error(message):
 ####################################################################
 class Interactive(Cmd):
     """This class implements the interactive interpreter functionality"""
-    intro = """Welcome to PKPass(Public Key Based Password Manager) v%s!
+    intro = """Welcome to PKPass (Public Key Based Password Manager) v%s!
 Type ? to list commands""" % VERSION
     prompt = 'pkpass> '
 ####################################################################


### PR DESCRIPTION
Looks like the introduction string when using the interactive mode is missing a space. Feel free to close if it's intentional.