### PR TITLE
allows users to distribute to a single person without overwriting

### DIFF
--- a/libpkpass/commands/distribute.py
+++ b/libpkpass/commands/distribute.py
@@ -47,6 +47,7 @@ class Distribute(Command):
                         passphrase=self.passphrase,
                         card_slot=self.args['card_slot'])
 
+                    password.read_password_data(dist_pass)
                     password.add_recipients(secret=plaintext_pw,
                                             distributor=self.args['identity'],
                                             recipients=self.recipient_list,

--- a/libpkpass/password.py
+++ b/libpkpass/password.py
@@ -111,9 +111,10 @@ class PasswordEntry():
         if recipients is None:
             recipients = []
 
-        self.recipients = {r:self._add_recipient(
+        new_recipients = {r:self._add_recipient(
             r, secret, distributor, identitydb, encryption_algorithm, passphrase, card_slot
         ) for r in recipients}
+        self.recipients.update(new_recipients)
         if escrow_users:
             #escrow_users may now be none after the set operations
             if (len(escrow_users) > 3) and (len(list((set(escrow_users) - set(recipients)))) < 3):


### PR DESCRIPTION
Before this fix, the user would have to know everyone that currently has a password to distribute to a new person.

This fix updates the dictionary.