### PR TITLE
add debug capability

### DIFF
--- a/docs/source/Commands.rst
+++ b/docs/source/Commands.rst
@@ -279,7 +279,7 @@ Export allows the current user to migrate all his passwords to one file, this te
 
     usage: pkpass.py export [-h] [--cabundle CABUNDLE] [-c CARD_SLOT]
                             [--certpath CERTPATH] [--color COLOR]
-                            [--dstpwstore DSTPWSTORE] [-i IDENTITY] [--no-cache]
+                            [-i IDENTITY] [--no-cache]
                             [--nocrypto] [--nopassphrase] [-q] [--stdin]
                             [--theme-map THEME_MAP] [-v]
                             [pwfile]
@@ -295,8 +295,6 @@ Export allows the current user to migrate all his passwords to one file, this te
       --certpath CERTPATH   Path to directory containing public keys. Certificates
                             must end in '.cert'
       --color COLOR         Disable color or not, accepts true/false
-      --dstpwstore DSTPWSTORE
-                            Path to the destination password store.
       -i IDENTITY, --identity IDENTITY
                             Override identity of user running the program
       --no-cache            if using a connector, pull the certs again
@@ -380,7 +378,7 @@ Import allows a user to take an exported password file and import them into a ne
 
     usage: pkpass.py import [-h] [--cabundle CABUNDLE] [-c CARD_SLOT]
                             [--certpath CERTPATH] [--color COLOR]
-                            [--dstpwstore DSTPWSTORE] [-i IDENTITY] [--no-cache]
+                            [-i IDENTITY] [--no-cache]
                             [--nocrypto] [--nopassphrase] [-q] [--stdin]
                             [--theme-map THEME_MAP] [-v]
                             [pwfile]
@@ -396,8 +394,6 @@ Import allows a user to take an exported password file and import them into a ne
       --certpath CERTPATH   Path to directory containing public keys. Certificates
                             must end in '.cert'
       --color COLOR         Disable color or not, accepts true/false
-      --dstpwstore DSTPWSTORE
-                            Path to the destination password store.
       -i IDENTITY, --identity IDENTITY
                             Override identity of user running the program
       --no-cache            if using a connector, pull the certs again

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -37,7 +37,6 @@ are arguments with 'store_true' or 'store_false' attributes. The following argum
     certpath
     color
     connect
-    dstpwstore
     escrow_users
     groups
     identity

--- a/libpkpass/commands/arguments.py
+++ b/libpkpass/commands/arguments.py
@@ -63,14 +63,6 @@ ARGUMENTS = {
         }
     },
 
-    'dstpwstore': {
-        'args': ['--dstpwstore'],
-        'kwargs': {
-            'type': str,
-            'help': 'Path to the destination password store.'
-        }
-    },
-
     'escrow_users': {
         'args':['-e', '--escrow_users'],
         'kwargs': {

--- a/libpkpass/commands/export.py
+++ b/libpkpass/commands/export.py
@@ -11,7 +11,7 @@ class Export(Command):
     ####################################################################
     name = 'export'
     description = 'Export passwords that you have access to and encrypt with aes'
-    selected_args = Command.selected_args + ['pwfile', 'stdin', 'nopassphrase', 'dstpwstore',
+    selected_args = Command.selected_args + ['pwfile', 'stdin', 'nopassphrase',
                                              'card_slot', 'nocrypto']
 
         ####################################################################

--- a/libpkpass/commands/fileimport.py
+++ b/libpkpass/commands/fileimport.py
@@ -13,7 +13,7 @@ class Import(Command):
     ####################################################################
     name = 'import'
     description = 'Import passwords that you have saved to a file'
-    selected_args = Command.selected_args + ['pwfile', 'stdin', 'nopassphrase', 'dstpwstore',
+    selected_args = Command.selected_args + ['pwfile', 'stdin', 'nopassphrase',
                                              'card_slot', 'nocrypto',]
 
         ####################################################################

--- a/libpkpass/commands/pkinterface.py
+++ b/libpkpass/commands/pkinterface.py
@@ -36,8 +36,12 @@ class PkInterface():
             description='Public Key Password Manager')
         self.parser.set_default_subparser = util.set_default_subparser
         self.parser.add_argument(
-            '--config', type=str, help="Path to a PKPass configuration file.  Defaults to '~/.pkpassrc'",
-            default=os.path.join(home, '.pkpassrc'))
+            '--config', type=str,
+            help="Path to a PKPass configuration file.  Defaults to '~/.pkpassrc'",
+            default=os.path.join(home, '.pkpassrc')
+        )
+        self.parser.add_argument('--debug', action='store_true',
+                                 help="Errors are more verbose")
         self.subparsers = self.parser.add_subparsers(
             help='sub-commands', dest='subparser_name')
 

--- a/libpkpass/password.py
+++ b/libpkpass/password.py
@@ -245,9 +245,8 @@ class PasswordEntry():
                     (self.metadata['name'], msg))
         except DecryptionError:
             msg = create_error_message(recipient_entry['timestamp'], card_slot)
-            raise DecryptionError(
-                "Error decrypting password named '%s'.  Perhaps a bad pin/passphrase?" %
-                self.metadata['name'])
+            raise DecryptionError("Error decrypting password named '%s'. %s" %
+                                  (self.metadata['name'], msg))
 
         #######################################################################
     def verify_entry(self, uid=None, iddb=None):

--- a/pkpass.py
+++ b/pkpass.py
@@ -6,10 +6,16 @@ if sys.version_info[0] < 3:
 
 # pylint: disable=wrong-import-position
 # Reasoning for the disablement is because we want people to not try to run with python2
+import argparse
 from traceback import format_exception_only
 from libpkpass.errors import PKPassError
 from libpkpass.commands.cli import Cli
 
+PARSER = argparse.ArgumentParser(add_help=False)
+# This debug flag exists in both this parser and the main parser
+# of Cli
+PARSER.add_argument("--debug", action='store_true')
+HIGH_LEVEL_ARGS, ARGS = PARSER.parse_known_args()
 try:
     Cli()
 except PKPassError as error:
@@ -20,8 +26,7 @@ except KeyboardInterrupt:
 # so that we can investigate
 # Comment this out for debugging
 except Exception as err: # pylint: disable=broad-except
-    if str(err):
-        print(err)
-    else:
-        print("Generic exception caught: \n%s" %
-              format_exception_only(type(err), err)[0])
+    if HIGH_LEVEL_ARGS.debug:
+        raise err
+    print("Generic exception caught: \n\t%s" %
+          format_exception_only(type(err), err)[0])

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,6 @@ for sanity sake Noah's return values were:
             'card_slot': '',
             'certpath': '',
             'connect': '',
-            'dstpwstore': '',
             'escrow_users': '',
             'groups': '',
             'identity': '',
@@ -206,7 +205,7 @@ class Verify(Command):
         return valid
 
     def check_paths(self, args_dict, valid):
-        args = ['cabundle', 'certpath', 'dstpwstore', 'pwstore']
+        args = ['cabundle', 'certpath', 'pwstore']
         for arg in args:
             if arg in args_dict.keys():
                 if not os.path.exists(args_dict[arg]):
@@ -219,7 +218,7 @@ class Verify(Command):
         import yaml
         valid = True
         args = ['cabundle', 'card_slot', 'certpath',
-                'connect', 'dstpwstore', 'escrow_users',
+                'connect', 'escrow_users',
                 'groups', 'identity', 'keypath',
                 'min_escrow', 'pwstore', 'time',
                 'rules', 'rules_map', 'users',


### PR DESCRIPTION
This adds the debug flag to the application, for purposes of unmasking errors.
Generic exception handler remains there to keep output tidy in most use cases, but the flag exists for the ability to figure out strange problems.